### PR TITLE
Remove idAs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "require-dev": {
     "phpunit/phpunit": "^9",
     "vlucas/phpdotenv": "^3.4",
-    "jeyroik/extas-repositories-mongo": "0.*"
+    "jeyroik/extas-repositories-mongo": "1.*"
   },
   "autoload": {
     "psr-4": {

--- a/src/components/extensions/ExtensionRepository.php
+++ b/src/components/extensions/ExtensionRepository.php
@@ -16,5 +16,4 @@ class ExtensionRepository extends RepositoryClassObjects implements IExtensionRe
     protected string $name = 'extensions';
     protected string $scope = 'extas';
     protected string $pk = Extension::FIELD__CLASS;
-    protected string $idAs = '';
 }

--- a/src/components/plugins/PluginRepository.php
+++ b/src/components/plugins/PluginRepository.php
@@ -25,7 +25,6 @@ class PluginRepository extends RepositoryClassObjects implements IPluginReposito
     protected string $name = 'plugins';
     protected string $pk = Plugin::FIELD__CLASS;
     protected string $scope = 'extas';
-    protected string $idAs = '';
 
     /**
      * Item constraints

--- a/src/components/repositories/Repository.php
+++ b/src/components/repositories/Repository.php
@@ -26,7 +26,6 @@ class Repository extends Item implements IRepository
     protected string $scope = 'extas';
     protected string $pk = '_id';
     protected string $itemClass = Item::class;
-    protected string $idAs = '';
 
     /**
      * Stages constraints
@@ -55,7 +54,6 @@ class Repository extends Item implements IRepository
         $this->table = DbCurrent::getTable($this->getName(), $this->getScope());
         $this->table->setPk($this->pk);
         $this->table->setItemClass($this->itemClass);
-        $this->table->setIdAs($this->idAs);
     }
 
     /**
@@ -222,14 +220,6 @@ class Repository extends Item implements IRepository
     public function getScope(): string
     {
         return $this->scope;
-    }
-
-    /**
-     * @return string
-     */
-    public function getIdAs(): string
-    {
-        return $this->idAs;
     }
 
     /**

--- a/src/components/repositories/RepositoryClassObjects.php
+++ b/src/components/repositories/RepositoryClassObjects.php
@@ -7,6 +7,7 @@ use extas\interfaces\IItem;
 /**
  * Class RepositoryClassObjects
  *
+ * @deprecated переписать на использование IHasClass.
  * @package extas\components\repositories
  * @author jeyroik@gmail.com
  */

--- a/src/components/repositories/clients/ClientTableAbstract.php
+++ b/src/components/repositories/clients/ClientTableAbstract.php
@@ -19,11 +19,6 @@ abstract class ClientTableAbstract implements IClientTable
     /**
      * @var string
      */
-    protected string $idAs = '_id';
-
-    /**
-     * @var string
-     */
     protected string $itemClass = '';
 
     /**
@@ -74,25 +69,5 @@ abstract class ClientTableAbstract implements IClientTable
     public function getItemClass(): string
     {
         return $this->itemClass;
-    }
-
-    /**
-     * @param string $fieldName
-     *
-     * @return $this
-     */
-    public function setIdAs($fieldName)
-    {
-        $this->idAs = $fieldName;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getIdAs()
-    {
-        return $this->idAs;
     }
 }

--- a/src/components/stages/StageRepository.php
+++ b/src/components/stages/StageRepository.php
@@ -17,7 +17,6 @@ class StageRepository extends Repository implements IStageRepository
     protected string $pk = IStage::FIELD__NAME;
     protected string $scope = 'extas';
     protected string $name = 'stages';
-    protected string $idAs = '';
 
     /**
      * Item constraints

--- a/src/interfaces/repositories/IRepository.php
+++ b/src/interfaces/repositories/IRepository.php
@@ -34,11 +34,6 @@ interface IRepository extends IItem
     /**
      * @return string
      */
-    public function getIdAs(): string;
-
-    /**
-     * @return string
-     */
     public function getItemClass(): string;
 
     /**

--- a/src/interfaces/repositories/clients/IClientTable.php
+++ b/src/interfaces/repositories/clients/IClientTable.php
@@ -108,18 +108,6 @@ interface IClientTable
     public function getItemClass(): string;
 
     /**
-     * @param $fieldName string
-     *
-     * @return $this
-     */
-    public function setIdAs($fieldName);
-
-    /**
-     * @return string
-     */
-    public function getIdAs();
-
-    /**
      * @param array $groupBy
      *
      * @return $this


### PR DESCRIPTION
- Removed `idAs` repository property.
- Removed `getIdAs` repository method.
- Removed `idAs` client table property.
- Removed `getIdAs`, `setIdAs` client table methods.